### PR TITLE
Rename `find_resource` method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lp_token_auth (0.2.5)
+    lp_token_auth (0.2.6)
       jwt (>= 1.5.6)
 
 GEM

--- a/lib/lp_token_auth/controller.rb
+++ b/lib/lp_token_auth/controller.rb
@@ -41,7 +41,7 @@ module LpTokenAuth
     def authenticate_token!(token, resource=:user)
       begin
         decoded = LpTokenAuth.decode!(token)
-        @current_user = find_resource(resource, decoded)
+        @current_user = find_lp_resource(resource, decoded)
       rescue LpTokenAuth::Error => error
         logout
         raise error
@@ -105,7 +105,7 @@ module LpTokenAuth
       LpTokenAuth.config.token_transport.include?(type)
     end
 
-    def find_resource(resource, decoded)
+    def find_lp_resource(resource, decoded)
       klass = resource.to_s.classify.constantize
       klass.find(decoded['id'])
     end

--- a/lib/lp_token_auth/version.rb
+++ b/lib/lp_token_auth/version.rb
@@ -1,4 +1,4 @@
 module LpTokenAuth
   # Current version of LpTokenAuth
-  VERSION = '0.2.5'.freeze
+  VERSION = '0.2.6'.freeze
 end

--- a/test/test_lp_token_auth_controller.rb
+++ b/test/test_lp_token_auth_controller.rb
@@ -79,7 +79,7 @@ class ControllerTest < MiniTest::Test
     describe 'with a valid token and resource' do
       it 'authenticates the request' do
         LpTokenAuth.stub :decode!, 'data' => token_str do
-          stub :find_resource, current_user do
+          stub :find_lp_resource, current_user do
             assert authenticate_request!(:mock_user)
           end
         end
@@ -87,7 +87,7 @@ class ControllerTest < MiniTest::Test
 
       it 'sets the current_user' do
         LpTokenAuth.stub :decode!, 'data' => token_str do
-          stub :find_resource, current_user do
+          stub :find_lp_resource, current_user do
             assert_equal MockUser.new.id, current_user.id
           end
         end


### PR DESCRIPTION
Ran into an issue with module method naming collision when using Active Admin. AA also implements a method named `find_resource`, so including `LpTokenAuth::Controller` in an AA controller breaks the controller actions. Renamed `LpTokenAuth`'s `find_resource` to `find_lp_resource`, though perhaps we think about converting these to class methods.